### PR TITLE
Implement Auth login and signup via JDBC

### DIFF
--- a/src/main/java/smu/db_project/auth/controller/AuthController.java
+++ b/src/main/java/smu/db_project/auth/controller/AuthController.java
@@ -1,0 +1,25 @@
+package smu.db_project.auth.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import smu.db_project.auth.dto.AuthResponseDto;
+import smu.db_project.auth.dto.LoginRequestDto;
+import smu.db_project.auth.service.AuthService;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<AuthResponseDto> login(@RequestBody LoginRequestDto request) {
+        AuthResponseDto response = authService.loginOrSignup(request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/smu/db_project/auth/dto/AuthResponseDto.java
+++ b/src/main/java/smu/db_project/auth/dto/AuthResponseDto.java
@@ -1,0 +1,11 @@
+package smu.db_project.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AuthResponseDto {
+    private String status;
+    private String message;
+}

--- a/src/main/java/smu/db_project/auth/dto/CategoryBudgetDto.java
+++ b/src/main/java/smu/db_project/auth/dto/CategoryBudgetDto.java
@@ -1,0 +1,15 @@
+package smu.db_project.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryBudgetDto {
+    private String categoryName;
+    private Integer limitAmount;
+}

--- a/src/main/java/smu/db_project/auth/dto/LoginRequestDto.java
+++ b/src/main/java/smu/db_project/auth/dto/LoginRequestDto.java
@@ -1,0 +1,17 @@
+package smu.db_project.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequestDto {
+    private StudentDto student;
+    private List<CategoryBudgetDto> categoryBudgets;
+}

--- a/src/main/java/smu/db_project/auth/dto/StudentDto.java
+++ b/src/main/java/smu/db_project/auth/dto/StudentDto.java
@@ -1,0 +1,17 @@
+package smu.db_project.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class StudentDto {
+    private Long sNum;
+    private String name;
+    private String sId;
+    private String password;
+}

--- a/src/main/java/smu/db_project/auth/repository/AuthRepository.java
+++ b/src/main/java/smu/db_project/auth/repository/AuthRepository.java
@@ -1,0 +1,51 @@
+package smu.db_project.auth.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+import smu.db_project.domain.Student;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class AuthRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    private final RowMapper<Student> studentRowMapper = (rs, rowNum) -> {
+        Student s = new Student();
+        s.setSNum(rs.getLong("S_NUM"));
+        s.setSId(rs.getString("S_ID"));
+        s.setName(rs.getString("NAME"));
+        s.setPassword(rs.getString("PASSWORD"));
+        return s;
+    };
+
+    public Student findStudentBySNum(Long sNum) {
+        String sql = "SELECT S_NUM, S_ID, NAME, PASSWORD FROM STUDENT WHERE S_NUM = ?";
+        List<Student> list = jdbcTemplate.query(sql, studentRowMapper, sNum);
+        return list.isEmpty() ? null : list.get(0);
+    }
+
+    public void insertStudent(Student student) {
+        String sql = "INSERT INTO STUDENT (S_NUM, S_ID, NAME, PASSWORD) VALUES (?, ?, ?, ?)";
+        jdbcTemplate.update(sql,
+                student.getSNum(),
+                student.getSId(),
+                student.getName(),
+                student.getPassword());
+    }
+
+    public Long findCategoryIdByName(String name) {
+        String sql = "SELECT ID FROM CATEGORY WHERE CATEGORY_NAME = ?";
+        List<Long> list = jdbcTemplate.query(sql, (rs, rowNum) -> rs.getLong("ID"), name);
+        return list.isEmpty() ? null : list.get(0);
+    }
+
+    public void insertCategoryBudget(Long sNum, Long categoryId, Integer limitAmount) {
+        String sql = "INSERT INTO CATEGORY_BUDGET (S_NUM, CATEGORY_ID, LIMIT_AMOUNT) VALUES (?, ?, ?)";
+        jdbcTemplate.update(sql, sNum, categoryId, limitAmount);
+    }
+}

--- a/src/main/java/smu/db_project/auth/service/AuthService.java
+++ b/src/main/java/smu/db_project/auth/service/AuthService.java
@@ -1,0 +1,47 @@
+package smu.db_project.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import smu.db_project.auth.dto.AuthResponseDto;
+import smu.db_project.auth.dto.CategoryBudgetDto;
+import smu.db_project.auth.dto.LoginRequestDto;
+import smu.db_project.auth.dto.StudentDto;
+import smu.db_project.auth.repository.AuthRepository;
+import smu.db_project.domain.Student;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final AuthRepository authRepository;
+
+    public AuthResponseDto loginOrSignup(LoginRequestDto request) {
+        StudentDto dto = request.getStudent();
+        Student existing = authRepository.findStudentBySNum(dto.getSNum());
+
+        if (existing == null) {
+            // sign up
+            Student student = new Student();
+            student.setSNum(dto.getSNum());
+            student.setSId(dto.getSId());
+            student.setName(dto.getName());
+            student.setPassword(dto.getPassword());
+            authRepository.insertStudent(student);
+
+            if (request.getCategoryBudgets() != null) {
+                for (CategoryBudgetDto b : request.getCategoryBudgets()) {
+                    Long catId = authRepository.findCategoryIdByName(b.getCategoryName());
+                    if (catId != null) {
+                        authRepository.insertCategoryBudget(dto.getSNum(), catId, b.getLimitAmount());
+                    }
+                }
+            }
+            return new AuthResponseDto("success", "회원가입 및 예산 등록 완료");
+        } else {
+            if (!existing.getPassword().equals(dto.getPassword())) {
+                return new AuthResponseDto("fail", "비밀번호가 올바르지 않습니다.");
+            }
+            return new AuthResponseDto("success", "로그인 성공");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add controller, service, repository for auth login and signup
- add DTOs for auth requests and responses
- implement JDBC-based repository without JPA

## Testing
- `./gradlew test --no-daemon` *(fails: Permission denied or no output)*

------
https://chatgpt.com/codex/tasks/task_e_684519ead7c8832f84b5927cd2f111ef